### PR TITLE
Screw it...

### DIFF
--- a/src/Blubber/Response.php
+++ b/src/Blubber/Response.php
@@ -223,15 +223,12 @@ class Response
                 extension_loaded('zlib') &&
                 array_key_exists('gzip', Request::getAcceptEncoding()))
             {
-                ob_start("ob_gzhandler");
-                echo $data;
-                ob_end_flush();
-            } else {
-                echo $data;
+                ob_start('ob_gzhandler');
             }
-        }
 
-        exit;
+            echo $data;
+            exit;
+        }
     }
 
     /**


### PR DESCRIPTION
Just keep use_output_compress set to false for now.  PHP has a possible
bug here.  Timeouts when using ob_gzhandler or any Zlib compression.
