### PR TITLE
Removed Request from Scrutinizer

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -3,3 +3,4 @@ filter:
         - index.php
         - autoloader.php
         - SplClassLoader.php
+        - src/Blubber/Request.php


### PR DESCRIPTION
Request will always be a getter class, and is as streamlined as possible
